### PR TITLE
fix: permit weak imports

### DIFF
--- a/Formula/delve.rb
+++ b/Formula/delve.rb
@@ -53,6 +53,8 @@ extendedKeyUsage        = critical,codeSigning
     mkdir_p buildpath/"src/github.com/derekparker"
     ln_sf buildpath, buildpath/"src/github.com/derekparker/delve"
 
+    ENV.permit_weak_imports
+
     ENV["GOBIN"] = buildpath
     ENV["GOPATH"] = buildpath
     ENV["CERT"] = dlv_cert


### PR DESCRIPTION
Adds the new directive added by homebrew team to get around the compile errors in 10.12 since weak imports are now disallowed by default.