### PR TITLE
Update Caveats to fix deprecation message

### DIFF
--- a/Formula/delve.rb
+++ b/Formula/delve.rb
@@ -65,7 +65,7 @@ extendedKeyUsage        = critical,codeSigning
     bin.install "dlv"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     If you get "could not launch process: could not fork/exec", you need to try
     in a new terminal.
 


### PR DESCRIPTION
Replace `<<-EOS.undent` with `<<~EOS` as per the brew deprecation notice

Closes go-delve/homebrew-delve/#25